### PR TITLE
[TASK] remove php7.4-imagick

### DIFF
--- a/t3kit8.9/php7.4-apache2.4-ubuntu18.04/Dockerfile
+++ b/t3kit8.9/php7.4-apache2.4-ubuntu18.04/Dockerfile
@@ -48,7 +48,6 @@ RUN apt-get update \
     php7.4-xml=7.4.* \
     php7.4-zip=7.4.* \
     php7.4-intl=7.4.* \
-    php7.4-imagick=7.4.* \
 && rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
Remove imagick, pushed to hub https://hub.docker.com/repository/docker/t3kit/8.9-php7.4-apache2.4-ubuntu18.04
